### PR TITLE
Security Update, make --user/--password optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,53 @@ which can be found at http://cefs.steve-meier.de/
 
 # Usage
   1. Sync repositories
-  2. Run the script - The user name and password can be found under /etc/pulp/server.conf    
-     wget -N http://cefs.steve-meier.de/errata.latest.xml  
-     ./errata_import.pl --errata=errata.latest.xml --user=[admin] --password=[pass]  
-  3. Go to "Administer" > "Settings" > "Katello" and set "force_post_sync_action" to true. (Katello 3.0 and up)
-  4. Sync repositories so that errata is published. (The errata will not show up on the Katello/Foreman interface until this step is completed. )
+  2. See [Authentication](#Authentication) Below
+  3. Run the script  
+     wget -N http://cefs.steve-meier.de/errata.latest.xml
+     ./errata_import.pl --errata=errata.latest.xml [--user=admin] [--password=pass]  
+  4. Go to "Administer" > "Settings" > "Katello" and set "force_post_sync_action" to true. (Katello 3.0 and up)
+  5. Sync repositories so that errata is published. (The errata will not show up on the Katello/Foreman interface until this step is completed. )
+
+# Authentication
+
+pulp-admin must authenticate to pulp.  This authentication information can be provided to pulp-admin in three ways.
+
+  1. User certificate (~/.pulp/user-cert.pem) **RECOMMENDED**  
+    If you are using this script with katello, the foreman-installer creates a certificate suitable for use with pulp.  You can use the cert by doing the following:
+
+    ```shell
+    sudo cat /etc/pki/katello/certs/pulp-client.crt /etc/pki/katello/private/pulp-client.key > ~/.pulp/user-cert.pem
+    chown 400 ~/pulp/user-cert.pem
+    ```
+  2. Admin configuration file (~/.pulp/admin.conf) **RECOMMENDED**  
+    You can provide the auth credentials in the pulp-admin configuration file.  Simply create ~/.pulp/admin.conf, you can get the password from /etc/pulp/server.conf (default_password).
+
+    ```ini
+    [auth]
+    username: admin
+    password: <password>
+    ```
+    Make sure the permissions on this file are restrictive.
+
+    ```shell
+    chmod 400 ~/.pulp/admin.conf
+    ```
+  3. Command line parameters (--user, --password) **NOT RECOMMENDED**  
+    It is **strongly** recommended that you do not use this method.
+
+    ```shell
+    ./errata_import.pl --errata=<errata_file> --user=admin --password=<password>
+    ```
+For methods 1 and 2, it is probably advisable to not store these credentials in a normal user's home directory.  You might consider using the root user for pulp-admin tasks.  Then non-privileged users can be given rights explicitly through sudo.  
 
 # Parameters 
 
 [Required]  
    --errata    - Path to the errata XML file.  
-   --user      - Pulp user (Usually admin, unless you are creating a pulp user specifically for this script).  
-   --password  - Pulp password (Found under /etc/pulp/server.conf, unless you are creating a pulp user specifically for this script).  
 
 [Optional]  
+   --user          - Pulp user (Usually admin, unless you are creating a pulp user specifically for this script).  
+   --password      - Pulp password (Found under /etc/pulp/server.conf, unless you are creating a pulp user specifically for this script).  
    --rhsa-oval     - Path to the OVAL XML file from Red Hat (recommended)  
    --include-repo  - Only consider packages and errata in the provided repositories. Can be provided multiple times.  
 
@@ -40,7 +73,7 @@ which can be found at http://cefs.steve-meier.de/
 
 # Warning
 
-- I offer no garantees that this script will work for you.
+- I offer no guarantees that this script will work for you.
   It is offered as is!
 - I have no previous experience with perl, so this script
   will probably look horrific to anyone familiar with the

--- a/sample_wrapper_script.sh
+++ b/sample_wrapper_script.sh
@@ -5,7 +5,12 @@ cd /tmp
 wget -N http://cefs.steve-meier.de/errata.latest.xml
 wget -N https://www.redhat.com/security/data/oval/com.redhat.rhsa-all.xml
 
-PASSWORD=$(grep -i ^default_password /etc/pulp/server.conf | awk '{print $2}')
+# See README.md about setting up the credentials for pulp-admin
+# It his **highly** recommended that the password be passed on the commandline.
 
-/sbin/errata_import.pl --errata=/tmp/errata.latest.xml --rhsa-oval=/tmp/com.redhat.rhsa-all.xml --user=admin --password=$PASSWORD --debug --include-repo=Org-CentOS_7_x86_64-CentOS_7_x86_64_Base Org-CentOS_7_x86_64-CentOS_7_x86_64_Updates Org-CentOS_7_x86_64-CentOS_7_x86_64_Extras
+/sbin/errata_import.pl --errata=/tmp/errata.latest.xml --rhsa-oval=/tmp/com.redhat.rhsa-all.xml --debug --include-repo=Org-CentOS_7_x86_64-CentOS_7_x86_64_Base Org-CentOS_7_x86_64-CentOS_7_x86_64_Updates Org-CentOS_7_x86_64-CentOS_7_x86_64_Extras
 
+# If all of the repos that you want to import the errata into contain an indentifying pattern
+# in their labels you can use something like the following to ensure you don't miss new repos.
+
+# pulp-admin repo list --fields id | awk '/CentOS/ { print "--include-repo="$NF }' | xargs /sbin/errata_import.pl --errata=/tmp/errata.latest.xml --rhsa-oval=/tmp/com.redhat.rhsa-all.xml


### PR DESCRIPTION
Passing passwords on the command line is a security risk.  Make
--user/--password optional in favor of using ~/.pulp/client-cert.pem
or ~/.pulp/admin.conf.

errata_import.pl:
* Make --user/--password optional and update usage
* Add a warning about using --user/--password
* Add $pulp_args and populate if --user/--password are used
* If user and password are NOT supplied verify one of
  ~/.pulp/user-cert.pem or ~/.pulp/admin.conf are available

sample_wrapper_script.sh:
* show usage without user/password
* show usage with pulp-admin repo list | aws | xargs

README.md:
* Update examples
* Update for making --user/--password optional
* Add section Authentication options